### PR TITLE
Current apps.json file load is backwards and over complicated

### DIFF
--- a/src/Wappalyzer.php
+++ b/src/Wappalyzer.php
@@ -32,7 +32,7 @@ class Wappalyzer
         }
         
         // Remote file load 
-        if (filter_var($app, FILTER_VALIDATE_URL) === true || $this->client === false) {
+        if (filter_var($app, FILTER_VALIDATE_URL) === true && $this->client !== false) {
             $response = $this->client->request("GET", $app);
             if ($response->getStatusCode() == 200) {
                 $appData = (string)$response->getBody();

--- a/src/Wappalyzer.php
+++ b/src/Wappalyzer.php
@@ -31,16 +31,19 @@ class Wappalyzer
             $this->client = $client;
         }
         
-        if ($this->client === false && (substr($app, 0, strlen('http://')) == 'http://' || substr($app, 0, strlen('https://')) == 'https://')) {
-            $appData = file_get_contents($app);
-        } else {
+        // Remote file load 
+        if (filter_var($app, FILTER_VALIDATE_URL) === true || $this->client === false) {
             $response = $this->client->request("GET", $app);
             if ($response->getStatusCode() == 200) {
-                $appData = (string) $response->getBody();
+                $appData = (string)$response->getBody();
             } else {
                 throw new Exception('Cannot parse Wappalizer data.');
             }
+        } else {
+            // No client available or local file
+            $appData = file_get_contents($app);
         }
+
         
         $appParsed = json_decode($appData, true);
         $this->apps = $appParsed['apps'];


### PR DESCRIPTION
Current code fails when using Laravel facade with a cURL error because it is trying to make guzzle load the local file ./vendor/madeitbelgium/wappalyzer/src/apps.json by default.  Use PHP's filter_var and validate for URL that way. Otherwise assume the file is local.  Also file_get_contents() can read remote locations but I suppose using guzzle is preferable.